### PR TITLE
Obey redirections in GitHub API

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -14,7 +14,8 @@ fi
 
 # Fetch all K3s versions usable for the specified partial version.
 # Even if the version is specific and complete, assume it is possibly partial.
-curl --silent --fail "${authz[@]}" "${GITHUB_API_URL}/repos/${REPO}/releases?per_page=999" |
+url="${GITHUB_API_URL}/repos/${REPO}/releases?per_page=999"
+curl --silent --fail --location "${authz[@]}" "$url" | \
   jq '.[] | select(.prerelease==false) | .tag_name' >/tmp/versions.txt
 
 echo "::group::All available K3s versions (unsorted)"


### PR DESCRIPTION
For reasons unknown, GitHub API responds this way to the API call:

```
$ curl -i 'https://api.github.com/repos/rancher/k3s/releases?per_page=999'
HTTP/1.1 301 Moved Permanently
…
status: 301 Moved Permanently
location: https://api.github.com/repositories/135516270/releases?per_page=999
…

{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/135516270/releases?per_page=999",
  "documentation_url": "https://docs.github.com/v3/#http-redirects"
}
```

I.e. the project name is replaced with the project id.

Let's follow the redirections.