### PR TITLE
Compatibility with ubuntu-18.04 runner

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -15,11 +15,11 @@ fi
 # Fetch all K3s versions usable for the specified partial version.
 # Even if the version is specific and complete, assume it is possibly partial.
 url="${GITHUB_API_URL}/repos/${REPO}/releases?per_page=999"
-curl --silent --fail --location "${authz[@]}" "$url" | \
-  jq '.[] | select(.prerelease==false) | .tag_name' >/tmp/versions.txt
+releases=$(curl --silent --fail --location "${authz[@]-}" "$url")
+versions=$(jq <<< "$releases" '.[] | select(.prerelease==false) | .tag_name')
 
 echo "::group::All available K3s versions (unsorted)"
-cat /tmp/versions.txt
+echo "$versions"
 echo "::endgroup::"
 
 # Sort the versions numerically, not lexographically:
@@ -28,7 +28,7 @@ echo "::endgroup::"
 # 2. Convert parts to numbers when possible ([1, 19, 4, 1]).
 # 3. Sort numerically instead of lexographically.
 # 4. Restore the original name of each version.
-jq --slurp '
+versions_sorted=$(jq --slurp <<< "$versions" '
   [ .[]
     | { original: .,
         numeric:
@@ -42,41 +42,41 @@ jq --slurp '
   | reverse
   | .[]
     | .original
-  ' </tmp/versions.txt >/tmp/sorted.txt
+  ')
 
 echo "::group::All available K3s versions (newest on top)"
-cat /tmp/sorted.txt
+echo "$versions_sorted"
 echo "::endgroup::"
 
 # The "latest" version is not directly exposed, but we hard-code its meaning.
 if [[ "${VERSION}" == "latest" ]]; then
-  VERSION=$(head -n 1 /tmp/sorted.txt | jq -r)
+  VERSION=$(jq --slurp <<< "$versions_sorted" --raw-output '.[0]')
 fi
 
 # The select only those versions that match the requested one.
 # Do not rely on the parsed forms of the versions -- they may miss some parts.
 # Rely only on the actual name of the version.
 # TODO: LATER: Handle release candidates: v1.18.2-rc3+k3s1 must be before v1.18.2+k3s1.
-jq --slurp --arg version "${VERSION}" '
+versions_matching=$(jq --slurp <<< "$versions_sorted" --arg version "${VERSION}" '
   .[]
   | select((.|startswith($version + ".")) or
            (.|startswith($version + "-")) or
            (.|startswith($version + "+")) or
            (.==$version))
-  ' </tmp/sorted.txt >/tmp/matching.txt
+  ')
 
 echo "::group::All matching K3s versions (newest on top)"
-cat /tmp/matching.txt
+echo "$versions_matching"
 echo "::endgroup::"
 
 # Validate that we could identify the version (even a very specific one).
-if [[ ! -s /tmp/matching.txt ]]; then
+if [[ -z "$versions_matching" ]]; then
   echo "::error::No matching K3s versions were found."
   exit 1
 fi
 
 # Get the best possible (i.e. the latest) version of K3s/K8s.
-K3S=$(head -n 1 /tmp/matching.txt | jq -r)
+K3S=$(jq --slurp <<< "$versions_matching" --raw-output '.[0]')
 K8S=${K3S%%+*}
 
 # Communicate back to GitHub Actions.


### PR DESCRIPTION
When I ran this action in the following matrix, both jobs failed with the jq help text, `jq - commandline JSON processor [version 1.5-1-a5b5cbe]`, followed by `head: write error: Broken pipe`.

```yaml
  kubernetes-k3d:
    runs-on: ubuntu-latest
    strategy:
      matrix:
        kubernetes: [latest, v1.18]
    steps:
      - uses: actions/checkout@v2
      - uses: actions/setup-go@v2
        with: { go-version: 1.x }
      - uses: nolar/setup-k3d-k3s@v1
        with:
          version: ${{ matrix.kubernetes }}
          k3d-args: --no-lb
```

This PR fixes two things:
1. Every invocation of `jq` has a filter. The default of `.` came about [in 1.6](https://github.com/stedolan/jq/releases/tag/jq-1.6), apparently. 
2. No more pipes. The GH bash runner enables `pipefail` but now the action behaves consistently without it.

Along the way, I replaced the temporary files with variables and here strings. Tested on Bash 3.2.57 (macOS Big Sur) and Bash 5.0.3 (debian buster).