### PR TITLE
Use sort --version-sort to sort versions

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -17,32 +17,7 @@ fi
 url="${GITHUB_API_URL}/repos/${REPO}/releases?per_page=999"
 releases=$(curl --silent --fail --location "${authz[@]-}" "$url")
 versions=$(jq <<< "$releases" '.[] | select(.prerelease==false) | .tag_name')
-
-echo "::group::All available K3s versions (unsorted)"
-echo "$versions"
-echo "::endgroup::"
-
-# Sort the versions numerically, not lexographically:
-# 0. Preserve the original name of the version.
-# 1. Split the version nmame ("v1.19.4+k3s1") into parts (["1", "19", "4", "1"]).
-# 2. Convert parts to numbers when possible ([1, 19, 4, 1]).
-# 3. Sort numerically instead of lexographically.
-# 4. Restore the original name of each version.
-versions_sorted=$(jq --slurp <<< "$versions" '
-  [ .[]
-    | { original: .,
-        numeric:
-          .
-          | ltrimstr("v")
-          | split("(-|\\.|\\+k3s)"; "")
-          | [ .[] | (tonumber? // .) ]
-      }
-  ]
-  | sort_by(.numeric)
-  | reverse
-  | .[]
-    | .original
-  ')
+versions_sorted=$(sort <<< "$versions" --field-separator=- --key=1,1rV --key=2,2rV)
 
 echo "::group::All available K3s versions (newest on top)"
 echo "$versions_sorted"


### PR DESCRIPTION
The `sort` utility knows how to compare version numbers. It differs from https://semver.org/ in that it compares `-` and `+` by codepoint rather than interpreting them as pre-release and build metadata. Splitting on `-` solves this.

I see that k3s has tagged their pre-releases correctly now in the GitHub API. If we want to trust that they'll continue to do that, no splitting is necessary:

```
● versions=$(printf '"%s"\n' v1.18.2-rc3+k3s1 v1.18.3 v1.19.0 v1.18.2+k3s1 v1.18.2-rc2+k3s1 v1.18.2-rc2+k3s2 v1.18.2-rc2+k3s10 v1.18.2+k3s10)

● sort <<< "$versions" --reverse --version-sort
"v1.19.0"
"v1.18.3"
"v1.18.2-rc3+k3s1"
"v1.18.2-rc2+k3s10"
"v1.18.2-rc2+k3s2"
"v1.18.2-rc2+k3s1"
"v1.18.2+k3s10"
"v1.18.2+k3s1"

● sort <<< "$versions" --field-separator=- --key=1,1rV --key=2,2rV
"v1.19.0"
"v1.18.3"
"v1.18.2+k3s10"
"v1.18.2+k3s1"
"v1.18.2-rc3+k3s1"
"v1.18.2-rc2+k3s10"
"v1.18.2-rc2+k3s2"
"v1.18.2-rc2+k3s1"
```