### PR TITLE
Accept a custom K3d tag/version as a parameter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,17 @@ jobs:
       - run: kubectl version --context k3d-1-20
       - run: kubectl version --context k3d-1-21
 
+  test-custom-tag:
+    name: Custom K3d tag
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./  # normally: nolar/setup-k3d-k3s@v1
+        with:
+          version: v1.21
+          k3d-tag: v4.4.8
+      - run: k3d --version
+
   test-custom-args:
     name: Custom args
     runs-on: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ as found in [K3s releases](https://github.com/k3s-io/k3s/releases),
 according to the basic semantical sorting (i.e. not by time of releasing).
 
 
+### `k3d-tag`
+
+A tag/version of K3d to use. Corresponds to GitHub tags at
+https://github.com/rancher/k3d/releases. For example, `v5.0.0`.
+`latest` is also accepted, but converted to an empty string
+for the installation script.
+
+By default (i.e. if no value is provided), the latest version is used.
+
+
 ### `k3d-name`
 
 A name of the cluster to be created.
@@ -118,7 +128,7 @@ The specific K8s version that was detected and used. E.g. `v1.21.2`.
 
 ## Examples
 
-With the latest version of K3s/K8s:
+With the latest version of K3d/K3s/K8s:
 
 ```yaml
 steps:
@@ -182,6 +192,20 @@ jobs:
           k3d-name: 1-21
       - run: kubectl version --context k3d-1-20 
       - run: kubectl version --context k3d-1-21 
+```
+
+Custom version of K3d can be used, if needed:
+
+```yaml
+jobs:
+  some-job:
+    name: Custom K3d version
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: nolar/setup-k3d-k3s@v1
+        with:
+          k3d-tag: v4.4.8
+      - run: k3d --version
 ```
 
 Custom args can be passed to K3d (and through it, to K3s & K8s):

--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ resources to appear (e.g., for a service account named "default").
 
 ## Outputs
 
+### `k3d-version`
+
+The specific K3d version that was detected and used. E.g. `v5.0.0`.
+
+
 ### `k3s-version`
 
 The specific K3s version that was detected and used. E.g. `v1.21.2+k3s1`.

--- a/action.sh
+++ b/action.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -eu
-#set -x # for debugging
 
 : ${GITHUB_API_URL:=https://api.github.com}
 : ${VERSION:=latest}
@@ -65,7 +64,11 @@ echo "::set-output name=k8s-version::${K8S}"
 
 # Install K3d and start a K3s cluster. It takes 20 seconds usually.
 # Name & args can be empty or multi-value. For this, they are not quoted.
-curl --silent --fail https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+if [[ "${K3D_TAG:-}" == "latest" ]]; then
+  K3D_TAG=""
+fi
+curl --silent --fail https://raw.githubusercontent.com/rancher/k3d/main/install.sh \
+  | TAG=${K3D_TAG:-} bash
 k3d --version
 k3d cluster create ${K3D_NAME:-} --wait --image=rancher/k3s:"${K3S//+/-}" ${K3D_ARGS:-}
 

--- a/action.sh
+++ b/action.sh
@@ -58,10 +58,6 @@ fi
 K3S=$(jq --slurp <<< "$versions_matching" --raw-output '.[0]')
 K8S=${K3S%%+*}
 
-# Communicate back to GitHub Actions.
-echo "::set-output name=k3s-version::${K3S}"
-echo "::set-output name=k8s-version::${K8S}"
-
 # Install K3d and start a K3s cluster. It takes 20 seconds usually.
 # Name & args can be empty or multi-value. For this, they are not quoted.
 if [[ "${K3D_TAG:-}" == "latest" ]]; then
@@ -70,6 +66,17 @@ fi
 curl --silent --fail https://raw.githubusercontent.com/rancher/k3d/main/install.sh \
   | TAG=${K3D_TAG:-} bash
 k3d --version
+K3D=$(k3d --version | grep -Po 'k3d version \K(v[\S]+)' || true )
+
+# Communicate back to GitHub Actions.
+echo "Detected k3d-version::${K3D}"
+echo "Detected k3s-version::${K3S}"
+echo "Detected k8s-version::${K8S}"
+echo "::set-output name=k3d-version::${K3D}"
+echo "::set-output name=k3s-version::${K3S}"
+echo "::set-output name=k8s-version::${K8S}"
+
+# Start a cluster. It takes 20 seconds usually.
 k3d cluster create ${K3D_NAME:-} --wait --image=rancher/k3s:"${K3S//+/-}" ${K3D_ARGS:-}
 
 # Sometimes, the service account is not created immediately. Nice trick, but no:

--- a/action.yaml
+++ b/action.yaml
@@ -26,6 +26,9 @@ inputs:
     description: Skip waiting for full cluster readiness?
     required: false
 outputs:
+  k3d-version:
+    description: Actual version of K3d detected and used.
+    value: ${{ steps.main.outputs.k3d-version }}
   k3s-version:
     description: Actual version of K3s detected and used.
     value: ${{ steps.main.outputs.k3s-version }}

--- a/action.yaml
+++ b/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: Full or partial version of K3s, or `latest`.
     required: true
     default: latest
+  k3d-tag:
+    description: K3d tag/version to use (by default, the latest one).
+    required: false
+    default: latest
   k3d-name:
     description: Cluster name.
     required: false
@@ -36,6 +40,7 @@ runs:
       run: ${{ github.action_path }}/action.sh
       env:
         VERSION: ${{ inputs.version }}
+        K3D_TAG: ${{ inputs.k3d-tag }}
         K3D_NAME: ${{ inputs.k3d-name }}
         K3D_ARGS: ${{ inputs.k3d-args }}
         GITHUB_TOKEN: ${{ inputs.github-token }}


### PR DESCRIPTION
```yaml
jobs:
  some-job:
    name: Custom K3d version
    runs-on: ubuntu-20.04
    steps:
      - uses: nolar/setup-k3d-k3s@v1
        with:
          k3d-tag: v4.4.8
      - run: k3d --version
```

See the README changes for examples.

Closes #14.