### PR TITLE
Accept k3s args in addition to k3d args, quote properly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,4 +105,7 @@ jobs:
         with:
           version: v1.35
           k3d-args: --servers 2 --no-lb
+          k3s-args: --disable=metrics-server@server:*
       - run: kubectl get nodes  # there must be two of them
+      - run: sleep 30  # metrics.k8s.io requires ≈20s to launch, otherwise absent
+      - run: "! kubectl api-resources | grep metrics.k8s.io"  # there must be none

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ Additional args to pass to K3d.
 See `k3d cluster create --help` for available flags.
 
 
+### `k3s-args`
+
+Additional args to pass to K3s (passed via K3d's `--k3s-arg`).
+See [k3s docs](https://docs.k3s.io/cli/server) for available flags.
+
+
 ### `github-token`
 
 A token for GitHub API, which is used to avoid rate limiting.
@@ -234,6 +240,7 @@ jobs:
       - uses: nolar/setup-k3d-k3s@v1
         with:
           k3d-args: --servers 2 --no-lb
+          k3s-args: --disable=metrics-server@server:*
       - run: kubectl get nodes  # there must be two of them
 ```
 

--- a/action.sh
+++ b/action.sh
@@ -17,7 +17,7 @@ fi
 versions=""
 for page in 1 2 ; do
   url="${GITHUB_API_URL}/repos/${REPO}/releases?per_page=999&page=${page}"
-  releases=$(curl --silent --fail --location "${authz[@]-}" "$url")
+  releases=$(curl --silent --fail --location "${authz[@]}" "$url")
   versions+=$(jq <<< "$releases" '.[] | select(.prerelease==false) | .tag_name')
   versions+=$'\n'
 done
@@ -76,16 +76,26 @@ echo "k3d-version=${K3D}" >> $GITHUB_OUTPUT
 echo "k3s-version=${K3S}" >> $GITHUB_OUTPUT
 echo "k8s-version=${K8S}" >> $GITHUB_OUTPUT
 
+# Convert direct k3d args to an array.for proper quoting.
+ARGS=( ${K3D_ARGS:-} )
+
+# Convert k3s args to k3d args to be passed down to k3s properly.
+if [[ -n "${K3S_ARGS:-}" ]]; then
+  for arg in ${K3S_ARGS}; do
+    ARGS+=( --k3s-arg "$arg" )
+  done
+fi
+
 # Start a cluster. It takes 20 seconds usually.
-if [[ -z "${SKIP_CREATION}" ]]; then
-  k3d cluster create ${K3D_NAME:-} --wait --image=rancher/k3s:"${K3S//+/-}" ${K3D_ARGS:-}
+if [[ -z "${SKIP_CREATION:-}" ]]; then
+  k3d cluster create ${K3D_NAME:-} --wait --image=rancher/k3s:"${K3S//+/-}" "${ARGS[@]}"
 else
   echo "Skipping the cluster creation. The cluster can be not fully ready yet."
 fi
 
 # Sometimes, the service account is not created immediately. Nice trick, but no:
 # we need to wait until the cluster is fully ready before starting the tests.
-if [[ -z "${SKIP_CREATION}" && -z "${SKIP_READINESS}" ]]; then
+if [[ -z "${SKIP_CREATION:-}" && -z "${SKIP_READINESS:-}" ]]; then
   echo "::group::Waiting for cluster readiness"
   while ! kubectl get serviceaccount default >/dev/null; do sleep 1; done
   echo "::endgroup::"

--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,9 @@ inputs:
   k3d-args:
     description: Additional arguments to k3d cluster create.
     required: false
+  k3s-args:
+    description: Additional arguments to k3s servers (passed via k3d).
+    required: false
   github-token:
     description: Optional GitHub token to overcome API rate limiting.
     required: false
@@ -49,6 +52,7 @@ runs:
         K3D_TAG: ${{ inputs.k3d-tag }}
         K3D_NAME: ${{ inputs.k3d-name }}
         K3D_ARGS: ${{ inputs.k3d-args }}
+        K3S_ARGS: ${{ inputs.k3s-args }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
         SKIP_CREATION: ${{ inputs.skip-creation && 'yes' || '' }}
         SKIP_READINESS: ${{ inputs.skip-readiness && 'yes' || '' }}


### PR DESCRIPTION
Example:

```yaml
jobs:
  some-job:
    name: Custom args
    runs-on: ubuntu-22.04
    steps:
      - uses: nolar/setup-k3d-k3s@v1
        with:
          k3d-args: --servers 2 --no-lb
          k3s-args: --disable=metrics-server@server:0
```