### PR TITLE
Wait for the default object in the default namespace when awaiting the cluster

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -97,7 +97,7 @@ fi
 # we need to wait until the cluster is fully ready before starting the tests.
 if [[ -z "${SKIP_CREATION:-}" && -z "${SKIP_READINESS:-}" ]]; then
   echo "::group::Waiting for cluster readiness"
-  while ! kubectl get serviceaccount default >/dev/null; do sleep 1; done
+  while ! kubectl get serviceaccount -n default default >/dev/null; do sleep 1; done
   echo "::endgroup::"
 else
   echo "Skipping the readiness wait. The cluster can be not fully ready yet."


### PR DESCRIPTION
In some cases, a different namespace (e.g., "ci") was the default one, so the check was checking for the object that will never appear. In that particular case, even the configured namespace did not appear.

We expect the specific k3s-produced object in the specific namespace, so hardcode both names.

Closes #21 