### PR TITLE
Verify the cluster state after setup with assertions in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,21 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./  # normally: nolar/setup-k3d-k3s@v1
-      - run: kubectl version
+      - name: Assert cluster accessibility
+        run: kubectl version
+      - name: Assert nodes are ready
+        run: |
+          READY=$(kubectl get nodes -o json | jq '[.items[] | select(.status.conditions[] | select(.type == "Ready" and .status == "True"))] | length')
+          TOTAL=$(kubectl get nodes -o json | jq '.items | length')
+          echo "Ready nodes: $READY / $TOTAL"
+          [[ "$READY" -eq "$TOTAL" ]]
+          [[ "$TOTAL" -gt 0 ]]
+      - name: Assert default resources exist
+        run: |
+          kubectl get namespace default
+          kubectl get namespace kube-system
+          kubectl get serviceaccount default -n default
+          kubectl get service kubernetes -n default
 
   test-specific:
     strategy:
@@ -31,7 +45,25 @@ jobs:
         with:
           version: ${{ matrix.k3s }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: kubectl version
+        id: install
+      - name: Assert cluster accessibility
+        run: kubectl version
+      - name: Assert server version matches requested
+        run: |
+          ACTUAL=$(kubectl version -o json | jq -r '.serverVersion.gitVersion')
+          echo "Requested: $REQUESTED"
+          echo "Actual: $ACTUAL"
+          [[ "$ACTUAL" == ${REQUESTED}* ]]
+        env:
+          REQUESTED: ${{ matrix.k3s }}
+      - name: Assert output version matches requested
+        run: |
+          echo "Requested: $REQUESTED"
+          echo "Output k3s-version: $K3S_VERSION"
+          [[ "$K3S_VERSION" == ${REQUESTED}* ]]
+        env:
+          REQUESTED: ${{ matrix.k3s }}
+          K3S_VERSION: ${{ steps.install.outputs.k3s-version }}
 
   test-outputs:
     name: Check outputs
@@ -43,8 +75,20 @@ jobs:
           version: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}
         id: install
-      - run: echo K3S=${K3S} K8S=${K8S}
+      - name: Assert outputs are non-empty and well-formed
+        run: |
+          echo "outputs.k3d-version: $K3D"
+          echo "outputs.k3s-version: $K3S"
+          echo "outputs.k8s-version: $K8S"
+          [[ -n "$K3D" ]]
+          [[ -n "$K3S" ]]
+          [[ -n "$K8S" ]]
+          [[ "$K3D" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]
+          [[ "$K3S" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\+k3s[0-9]+ ]]
+          [[ "$K8S" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          [[ "$K3S" == ${K8S}+k3s* ]]
         env:
+          K3D: ${{ steps.install.outputs.k3d-version }}
           K3S: ${{ steps.install.outputs.k3s-version }}
           K8S: ${{ steps.install.outputs.k8s-version }}
 
@@ -57,6 +101,12 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           skip-creation: true
+      - name: Assert tools are installed but no cluster exists
+        run: |
+          k3d --version
+          COUNT=$(k3d cluster list -o json | jq 'length')
+          echo "Cluster count: $COUNT"
+          [[ "$COUNT" -eq 0 ]]
 
   test-skip-readiness:
     name: Skip readiness
@@ -67,7 +117,13 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           skip-readiness: true
-      - run: kubectl version
+      - name: Assert cluster accessibility
+        run: kubectl version
+      - name: Assert cluster exists
+        run: |
+          COUNT=$(k3d cluster list -o json | jq 'length')
+          echo "Cluster count: $COUNT"
+          [[ "$COUNT" -eq 1 ]]
 
   test-multi-cluster:
     name: Multi-cluster
@@ -82,8 +138,23 @@ jobs:
         with:
           version: v1.35
           k3d-name: 1-35
-      - run: kubectl version --context k3d-1-34
-      - run: kubectl version --context k3d-1-35
+      - name: Assert cluster accessibility (1-34)
+        run: kubectl version --context k3d-1-34
+      - name: Assert cluster accessibility (1-35)
+        run: kubectl version --context k3d-1-35
+      - name: Assert both clusters exist
+        run: |
+          COUNT=$(k3d cluster list -o json | jq 'length')
+          echo "Cluster count: $COUNT"
+          [[ "$COUNT" -eq 2 ]]
+      - name: Assert cluster versions match
+        run: |
+          V34=$(kubectl version --context k3d-1-34 -o json | jq -r '.serverVersion.gitVersion')
+          V35=$(kubectl version --context k3d-1-35 -o json | jq -r '.serverVersion.gitVersion')
+          echo "Cluster 1-34: $V34"
+          echo "Cluster 1-35: $V35"
+          [[ "$V34" == v1.34.* ]]
+          [[ "$V35" == v1.35.* ]]
 
   test-custom-tag:
     name: Custom K3d tag
@@ -94,7 +165,11 @@ jobs:
         with:
           version: v1.35
           k3d-tag: v5.8.3
-      - run: k3d --version
+      - name: Assert k3d version matches requested tag
+        run: |
+          ACTUAL=$(k3d --version | awk 'NR==1{print $3}')
+          echo "Actual k3d version: $ACTUAL"
+          [[ "$ACTUAL" == "v5.8.3" ]]
 
   test-custom-args:
     name: Custom args
@@ -106,6 +181,17 @@ jobs:
           version: v1.35
           k3d-args: --servers 2 --no-lb
           k3s-args: --disable=metrics-server@server:*
-      - run: kubectl get nodes  # there must be two of them
-      - run: sleep 30  # metrics.k8s.io requires ≈20s to launch, otherwise absent
-      - run: "! kubectl api-resources | grep metrics.k8s.io"  # there must be none
+      - name: Assert exactly 2 server nodes
+        run: |
+          COUNT=$(kubectl get nodes -o json | jq '.items | length')
+          echo "Node count: $COUNT"
+          [[ "$COUNT" -eq 2 ]]
+      - name: Assert all nodes are ready
+        run: |
+          NOT_READY=$(kubectl get nodes -o json | jq '[.items[] | select(.status.conditions[] | select(.type == "Ready" and .status != "True"))] | length')
+          echo "Not ready: $NOT_READY"
+          [[ "$NOT_READY" -eq 0 ]]
+      - name: Assert metrics-server is disabled
+        run: |
+          sleep 30  # metrics.k8s.io requires ~20s to launch if enabled
+          ! kubectl api-resources 2>/dev/null | grep -q metrics.k8s.io


### PR DESCRIPTION
Each CI job now validates the action's results beyond basic connectivity: node readiness, expected versions, presence of default resources, output format consistency, cluster count, and feature-specific behavior like disabled components. Assertions use kubectl JSON output parsed with jq.

Basically, these are the tests.