### PR TITLE
Accept k3s versions out of visible history, use as is

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,30 @@ jobs:
           REQUESTED: ${{ matrix.k3s }}
           K3S_VERSION: ${{ steps.install.outputs.k3s-version }}
 
+  test-specific-outdated:
+    name: Install outdated
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./  # normally: nolar/setup-k3d-k3s@v1
+        with:
+          version: v1.30.2+k3s2  # pick something out of visible history
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        id: install
+      - name: Assert cluster accessibility
+        run: kubectl version
+      - name: Assert server version matches requested
+        run: |
+          ACTUAL=$(kubectl version -o json | jq -r '.serverVersion.gitVersion')
+          echo "Actual: $ACTUAL"
+          [[ "$ACTUAL" == "v1.30.2+k3s2" ]]
+      - name: Assert output version matches requested
+        run: |
+          echo "Output k3s-version: $K3S_VERSION"
+          [[ "$K3S_VERSION" == "v1.30.2+k3s2" ]]
+        env:
+          K3S_VERSION: ${{ steps.install.outputs.k3s-version }}
+
   test-outputs:
     name: Check outputs
     runs-on: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ When the version is partial, the latest detected one will be used,
 as found in [K3s releases](https://github.com/k3s-io/k3s/releases),
 according to the basic semantical sorting (i.e. not by time of releasing).
 
+If the version is not found in the recent releases (e.g. a very old version), it is used as is, assuming it is a valid K3s image tag.
+
 
 ### `k3d-tag`
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.21  # E.g.: v1.21, v1.21.2, v1.21.2+k3s1
+          version: v1.35  # E.g.: v1.35, v1.35.3, v1.35.3+k3s1, v1.35+stable
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
@@ -43,9 +43,9 @@ jobs:
 
 The following notations are supported:
 
-* `v1.21.2+k3s1`
-* `v1.21.2`
-* `v1.21`
+* `v1.35.3+k3s1`
+* `v1.35.3`
+* `v1.35`
 * `v1`
 * `latest`
 
@@ -139,12 +139,12 @@ The specific K3d version that was detected and used. E.g. `v5.0.0`.
 
 ### `k3s-version`
 
-The specific K3s version that was detected and used. E.g. `v1.21.2+k3s1`.
+The specific K3s version that was detected and used. E.g. `v1.35.3+k3s1`.
 
 
 ### `k8s-version`
 
-The specific K8s version that was detected and used. E.g. `v1.21.2`.
+The specific K8s version that was detected and used. E.g. `v1.35.3`.
 
 
 ## Examples
@@ -163,7 +163,7 @@ of K8s and the latest possible version of K3s:
 steps:
   - uses: nolar/setup-k3d-k3s@v1
     with:
-      version: v1.21
+      version: v1.35
 ```
 
 With the very specific version of K3s:
@@ -172,7 +172,7 @@ With the very specific version of K3s:
 steps:
   - uses: nolar/setup-k3d-k3s@v1
     with:
-      version: v1.21.2+k3s1
+      version: v1.35.3+k3s1
 ```
 
 The partial versions enable the build matrices with only the essential
@@ -185,9 +185,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s: [ v1.21, v1.20, v1.19, v1.18 ]
+        k8s: [ v1.35, v1.34, v1.33, v1.32 ]
     name: K8s ${{ matrix.k8s }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: nolar/setup-k3d-k3s@v1
         with:
@@ -201,18 +201,18 @@ Multiple clusters in one job are possible, as long as there is enough memory
 jobs:
   some-job:
     name: Multi-cluster
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.20
-          k3d-name: 1-20
+          version: v1.34
+          k3d-name: 1-34
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.21
-          k3d-name: 1-21
-      - run: kubectl version --context k3d-1-20 
-      - run: kubectl version --context k3d-1-21 
+          version: v1.35
+          k3d-name: 1-35
+      - run: kubectl version --context k3d-1-34 
+      - run: kubectl version --context k3d-1-35 
 ```
 
 Custom version of K3d can be used, if needed:
@@ -221,7 +221,7 @@ Custom version of K3d can be used, if needed:
 jobs:
   some-job:
     name: Custom K3d version
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: nolar/setup-k3d-k3s@v1
         with:
@@ -235,7 +235,7 @@ Custom args can be passed to K3d (and through it, to K3s & K8s):
 jobs:
   some-job:
     name: Custom args
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: nolar/setup-k3d-k3s@v1
         with:

--- a/action.sh
+++ b/action.sh
@@ -63,14 +63,14 @@ echo "::group::All matching K3s versions (newest on top)"
 echo "$versions_matching"
 echo "::endgroup::"
 
-# Validate that we could identify the version (even a very specific one).
-if [[ -z "$versions_matching" ]]; then
-  echo "::error::No matching K3s versions were found."
-  exit 1
-fi
-
 # Get the best possible (i.e. the latest) version of K3s/K8s.
-K3S=$(jq --slurp <<< "$versions_matching" --raw-output '.[0]')
+# If no matching versions were found, assume the provided version is full and correct.
+if [[ -z "$versions_matching" ]]; then
+  echo "::notice::No matching K3s versions were found in the recent releases; using the version string as is: ${VERSION}"
+  K3S="${VERSION}"
+else
+  K3S=$(jq --slurp <<< "$versions_matching" --raw-output '.[0]')
+fi
 K8S=${K3S%%+*}
 
 # Install K3d and start a K3s cluster. It takes 20 seconds usually.

--- a/action.sh
+++ b/action.sh
@@ -31,7 +31,7 @@ fi
 # 2-3 pages are enough to reach v0 while not depleting the GitHub API limits.
 versions=""
 for page in 1 2 ; do
-  url="${GITHUB_API_URL}/repos/${REPO}/releases?per_page=999&page=${page}"
+  url="${GITHUB_API_URL}/repos/${REPO}/releases?per_page=100&page=${page}"
   releases=$(curlex "${authz[@]}" "$url")
   versions+=$(jq <<< "$releases" '.[] | select(.prerelease==false) | .tag_name')
   versions+=$'\n'

--- a/action.yaml
+++ b/action.yaml
@@ -6,7 +6,7 @@ branding:
   color: yellow
 inputs:
   version:
-    description: Full or partial version of K3s, or `latest`.
+    description: Full or partial version of K3s, or `latest`. If the version is not found in the recent releases, it is used as is.
     required: true
     default: latest
   k3d-tag:


### PR DESCRIPTION
The visible history now is 200 releases of k3s, minus all release-candidates. This gives roughly 70-72 regular releases. The manual check shows that it spans way beyond the officially maintained k8s versions, by a lot (visually, two times farther or so). So, the history length (2 pages by 100 release) is good enough, no need to expand — it would consume the GitHub API for no good reason.

If someone needs a version that is beyond the visible history, they can manually pin it like this — but ALL components are needed, no "matching" or "guessing" is performed:

```yaml
with:
  version: v1.30.2+k3s2
```

Or for k3d channels:

```yaml
with:
  version: v1.35+stable
```

Closes #23, affects #16 
