### PR TITLE
Support k3s release channels via k3d

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   test-latest:
-    name: Install latest
+    name: Version latest
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         k3s: [v1.35.2+k3s1, v1.35.2, v1.35, v1]
-    name: Install ${{ matrix.k3s }}
+    name: Version ${{ matrix.k3s }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -66,7 +66,7 @@ jobs:
           K3S_VERSION: ${{ steps.install.outputs.k3s-version }}
 
   test-specific-outdated:
-    name: Install outdated
+    name: Version outdated
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -88,6 +88,40 @@ jobs:
           [[ "$K3S_VERSION" == "v1.30.2+k3s2" ]]
         env:
           K3S_VERSION: ${{ steps.install.outputs.k3s-version }}
+
+  test-channel-stable:
+    name: Channel stable
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./  # normally: nolar/setup-k3d-k3s@v1
+        with:
+          channel: stable  # usually latest-1
+        id: install
+      - name: Assert cluster accessibility
+        run: kubectl version
+      - name: Assert server version is well-formed
+        run: |
+          ACTUAL=$(kubectl version -o json | jq -r '.serverVersion.gitVersion')
+          echo "Actual: $ACTUAL"
+          [[ "$ACTUAL" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]
+
+  test-channel-versioned:
+    name: Channel v1.33
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./  # normally: nolar/setup-k3d-k3s@v1
+        with:
+          channel: v1.33
+        id: install
+      - name: Assert cluster accessibility
+        run: kubectl version
+      - name: Assert server version matches requested channel
+        run: |
+          ACTUAL=$(kubectl version -o json | jq -r '.serverVersion.gitVersion')
+          echo "Actual: $ACTUAL"
+          [[ "$ACTUAL" == v1.33.* ]]
 
   test-outputs:
     name: Check outputs

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.35  # E.g.: v1.35, v1.35.3, v1.35.3+k3s1, v1.35+stable
+          version: v1.35  # E.g.: v1.35, v1.35.3, v1.35.3+k3s1
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
@@ -51,6 +51,8 @@ The following notations are supported:
 
 Defaults to `latest`.
 
+Mutually exclusive with `channel`.
+
 Keep in mind that K3d dates back only to v1.16.
 There are no 1.15 and older versions of K8s.
 Besides, 1.16 and 1.17 are broken and will not be fixed
@@ -60,7 +62,27 @@ When the version is partial, the latest detected one will be used,
 as found in [K3s releases](https://github.com/k3s-io/k3s/releases),
 according to the basic semantical sorting (i.e. not by time of releasing).
 
-If the version is not found in the recent releases (e.g. a very old version), it is used as is, assuming it is a valid K3s image tag.
+If the version is not found in the recent releases (e.g. a very old version),
+it is used as is, assuming it is a valid K3s image tag.
+
+
+### `channel`
+
+A [K3s release channel](https://update.k3s.io/v1-release/channels) name,
+e.g. `stable`, `latest`, `testing`, or `v1.35`.
+Passed directly to K3d, which resolves it to a specific version.
+No GitHub API calls are made when a channel is used.
+
+Mutually exclusive with `version`.
+
+Note: `version: latest` and `channel: latest` are functionally equivalent
+and usually resolve to the same version, but they work differently.
+`version: latest` is resolved by this action via the GitHub API;
+`channel: latest` is resolved by K3d itself.
+
+When a channel is used, the version lookup is not performed, so the
+`k3s-version` and `k8s-version` outputs are empty.
+This may change in the future.
 
 
 ### `k3d-tag`
@@ -215,6 +237,15 @@ jobs:
           k3d-name: 1-35
       - run: kubectl version --context k3d-1-34 
       - run: kubectl version --context k3d-1-35 
+```
+
+With a K3s release channel (K3d resolves it to a specific version):
+
+```yaml
+steps:
+  - uses: nolar/setup-k3d-k3s@v1
+    with:
+      channel: stable
 ```
 
 Custom version of K3d can be used, if needed:

--- a/action.sh
+++ b/action.sh
@@ -26,52 +26,52 @@ else
   authz=()
 fi
 
-# Fetch all K3s versions usable for the specified partial version.
-# Even if the version is specific and complete, assume it is possibly partial.
-# 2-3 pages are enough to reach v0 while not depleting the GitHub API limits.
-versions=""
-for page in 1 2 ; do
-  url="${GITHUB_API_URL}/repos/${REPO}/releases?per_page=100&page=${page}"
-  releases=$(curlex "${authz[@]}" "$url")
-  versions+=$(jq <<< "$releases" '.[] | select(.prerelease==false) | .tag_name')
-  versions+=$'\n'
-done
-versions_sorted=$(sort <<< "$versions" --field-separator=- --key=1,1rV --key=2,2rV)
+  # Fetch all K3s versions usable for the specified partial version.
+  # Even if the version is specific and complete, assume it is possibly partial.
+  # 2-3 pages are enough to reach v0 while not depleting the GitHub API limits.
+  versions=""
+  for page in 1 2 ; do
+    url="${GITHUB_API_URL}/repos/${REPO}/releases?per_page=100&page=${page}"
+    releases=$(curlex "${authz[@]}" "$url")
+    versions+=$(jq <<< "$releases" '.[] | select(.prerelease==false) | .tag_name')
+    versions+=$'\n'
+  done
+  versions_sorted=$(sort <<< "$versions" --field-separator=- --key=1,1rV --key=2,2rV)
 
-echo "::group::All available K3s versions (newest on top)"
-echo "$versions_sorted"
-echo "::endgroup::"
+  echo "::group::All available K3s versions (newest on top)"
+  echo "$versions_sorted"
+  echo "::endgroup::"
 
-# The "latest" version is not directly exposed, but we hard-code its meaning.
-if [[ "${VERSION}" == "latest" ]]; then
-  VERSION=$(jq --slurp <<< "$versions_sorted" --raw-output '.[0]')
-fi
+  # The "latest" version is not directly exposed, but we hard-code its meaning.
+  if [[ "${VERSION}" == "latest" ]]; then
+    VERSION=$(jq --slurp <<< "$versions_sorted" --raw-output '.[0]')
+  fi
 
-# The select only those versions that match the requested one.
-# Do not rely on the parsed forms of the versions -- they may miss some parts.
-# Rely only on the actual name of the version.
-# TODO: LATER: Handle release candidates: v1.18.2-rc3+k3s1 must be before v1.18.2+k3s1.
-versions_matching=$(jq --slurp <<< "$versions_sorted" --arg version "${VERSION}" '
-  .[]
-  | select((.|startswith($version + ".")) or
-           (.|startswith($version + "-")) or
-           (.|startswith($version + "+")) or
-           (.==$version))
-  ')
+  # The select only those versions that match the requested one.
+  # Do not rely on the parsed forms of the versions -- they may miss some parts.
+  # Rely only on the actual name of the version.
+  # TODO: LATER: Handle release candidates: v1.18.2-rc3+k3s1 must be before v1.18.2+k3s1.
+  versions_matching=$(jq --slurp <<< "$versions_sorted" --arg version "${VERSION}" '
+    .[]
+    | select((.|startswith($version + ".")) or
+             (.|startswith($version + "-")) or
+             (.|startswith($version + "+")) or
+             (.==$version))
+    ')
 
-echo "::group::All matching K3s versions (newest on top)"
-echo "$versions_matching"
-echo "::endgroup::"
+  echo "::group::All matching K3s versions (newest on top)"
+  echo "$versions_matching"
+  echo "::endgroup::"
 
-# Get the best possible (i.e. the latest) version of K3s/K8s.
-# If no matching versions were found, assume the provided version is full and correct.
-if [[ -z "$versions_matching" ]]; then
-  echo "::notice::No matching K3s versions were found in the recent releases; using the version string as is: ${VERSION}"
-  K3S="${VERSION}"
-else
-  K3S=$(jq --slurp <<< "$versions_matching" --raw-output '.[0]')
-fi
-K8S=${K3S%%+*}
+  # Get the best possible (i.e. the latest) version of K3s/K8s.
+  # If no matching versions were found, assume the provided version is full and correct.
+  if [[ -z "$versions_matching" ]]; then
+    echo "::notice::No matching K3s versions were found in the recent releases; using the version string as is: ${VERSION}"
+    K3S="${VERSION}"
+  else
+    K3S=$(jq --slurp <<< "$versions_matching" --raw-output '.[0]')
+  fi
+  K8S=${K3S%%+*}
 
 # Install K3d and start a K3s cluster. It takes 20 seconds usually.
 # Name & args can be empty or multi-value. For this, they are not quoted.

--- a/action.sh
+++ b/action.sh
@@ -26,6 +26,14 @@ else
   authz=()
 fi
 
+# K3s channels (e.g. stable, v1.35) are passed directly to k3d as the image.
+# See https://update.k3s.io/v1-release/channels for the list of channels.
+if [[ -n "${CHANNEL:-}" ]]; then
+  K3S=""
+  K8S=""
+  IMAGE="+${CHANNEL}"
+else
+
   # Fetch all K3s versions usable for the specified partial version.
   # Even if the version is specific and complete, assume it is possibly partial.
   # 2-3 pages are enough to reach v0 while not depleting the GitHub API limits.
@@ -72,6 +80,9 @@ fi
     K3S=$(jq --slurp <<< "$versions_matching" --raw-output '.[0]')
   fi
   K8S=${K3S%%+*}
+  IMAGE="rancher/k3s:${K3S//+/-}"
+
+fi
 
 # Install K3d and start a K3s cluster. It takes 20 seconds usually.
 # Name & args can be empty or multi-value. For this, they are not quoted.
@@ -103,7 +114,7 @@ fi
 
 # Start a cluster. It takes 20 seconds usually.
 if [[ -z "${SKIP_CREATION:-}" ]]; then
-  k3d cluster create ${K3D_NAME:-} --wait --image=rancher/k3s:"${K3S//+/-}" "${ARGS[@]}"
+  k3d cluster create ${K3D_NAME:-} --wait --image="${IMAGE}" "${ARGS[@]}"
 else
   echo "Skipping the cluster creation. The cluster can be not fully ready yet."
 fi

--- a/action.yaml
+++ b/action.yaml
@@ -6,9 +6,12 @@ branding:
   color: yellow
 inputs:
   version:
-    description: Full or partial version of K3s, or `latest`. If the version is not found in the recent releases, it is used as is.
-    required: true
+    description: Full or partial version of K3s, or `latest`. If the version is not found in the recent releases, it is used as is. Mutually exclusive with `channel`.
+    required: false
     default: latest
+  channel:
+    description: K3s release channel (e.g. `stable`, `latest`, `testing`, `v1.35`). Passed directly to K3d, which resolves it to a specific version. Mutually exclusive with `version`.
+    required: false
   k3d-tag:
     description: K3d tag/version to use (by default, the latest one).
     required: false
@@ -49,6 +52,7 @@ runs:
       run: ${{ github.action_path }}/action.sh
       env:
         VERSION: ${{ inputs.version }}
+        CHANNEL: ${{ inputs.channel }}
         K3D_TAG: ${{ inputs.k3d-tag }}
         K3D_NAME: ${{ inputs.k3d-name }}
         K3D_ARGS: ${{ inputs.k3d-args }}


### PR DESCRIPTION
A new feature — release channels of k3s (via k3d). In that case, skip the GitHub API version resolution entirely and pass the channel string directly to K3d as the image, letting K3d resolve it to a specific K3s version. This avoids unnecessary API calls and enables using any channel from https://update.k3s.io/v1-release/channels.

Examples:

```yaml
with:
  channel: latest
```
```yaml
with:
  channel: stable
```
```yaml
with:
  channel: testing
```
```yaml
with:
  channel: v1.33
```

Closes #16 
